### PR TITLE
Add auto close PSD option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ TypeR is a better version of TyperTools, a Photoshop extension designed for type
 - **Text Smoothing Issue Resolved**: Fixed the bug that changed text smoothing from "Strong" to "Smooth" when increasing text size.  
 - **Stable Auto-Centering**: Text shape no longer changes when using auto-centering.  
 - **Customizable Shortcuts**: You can now modify keyboard shortcuts. (+ added some new keyboard shortcuts)  
-- **Automatic Page Detection**: Automatically detects pages when importing.  
-- **Automatic Page Switching**: Automatically switches pages for seamless workflow.  
-- **Resize TypeR**: Decreased size limit of the TypeR window so it can be much smaller.  
+- **Automatic Page Detection**: Automatically detects pages when importing.
+- **Automatic Page Switching**: Automatically switches pages for seamless workflow.
+- **Auto close PSD**: Optionally close the previous page's PSD when a new one opens.
+- **Resize TypeR**: Decreased size limit of the TypeR window so it can be much smaller.
 - **Line Spacing Sync**: When increasing/decreasing text size with TypeR, line spacing adjusts accordingly.  
 - **Adaptive Size**: If no fixed text size is defined, the size of the selected layer will be used.  
 - **Line Break on Insert**: A line break is now automatically added when inserting text on the current layer.  

--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -14,6 +14,7 @@ const SettingsModal = React.memo(function SettingsModal() {
   const [ignoreLinePrefixes, setIgnoreLinePrefixes] = React.useState(context.state.ignoreLinePrefixes.join(" "));
   const [defaultStyleId, setDefaultStyleId] = React.useState(context.state.defaultStyleId || "");
   const [language, setLanguage] = React.useState(context.state.language || "auto");
+  const [autoClosePsd, setAutoClosePsd] = React.useState(context.state.autoClosePsd || false);
   const [edited, setEdited] = React.useState(false);
 
   const close = () => {
@@ -37,6 +38,11 @@ const SettingsModal = React.memo(function SettingsModal() {
 
   const changeLanguage = (e) => {
     setLanguage(e.target.value);
+    setEdited(true);
+  };
+
+  const changeAutoClosePsd = (e) => {
+    setAutoClosePsd(e.target.checked);
     setEdited(true);
   };
 
@@ -66,6 +72,12 @@ const SettingsModal = React.memo(function SettingsModal() {
         lang: language,
       });
       setTimeout(() => window.location.reload(), 100);
+    }
+    if (autoClosePsd !== context.state.autoClosePsd) {
+      context.dispatch({
+        type: "setAutoClosePsd",
+        value: autoClosePsd,
+      });
     }
     const shortcut = {};
     document.querySelectorAll("input[id^=shortcut_]").forEach((input) => {
@@ -169,6 +181,15 @@ const SettingsModal = React.memo(function SettingsModal() {
                     </option>
                   ))}
                 </select>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsAutoClosePsdLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={autoClosePsd} onChange={changeAutoClosePsd} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
               </div>
             </div>
             <div className="field hostBrdTopContrast">

--- a/app_src/components/textBlock/textBlock.jsx
+++ b/app_src/components/textBlock/textBlock.jsx
@@ -42,7 +42,10 @@ const TextBlock = React.memo(function TextBlock() {
       return " ";
     }
     if (context.state.currentLineIndex === line.rawIndex && context.state.images[currentPage]) {
-      openFile(context.state.images[currentPage].path);
+      openFile(
+        context.state.images[currentPage].path,
+        context.state.autoClosePsd
+      );
     }
     return line.index;
   };

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -4,7 +4,21 @@ import { locale, readStorage, writeToStorage, scrollToLine, scrollToStyle, check
 import config from "./config";
 
 const storage = readStorage();
-const storeFields = ["notFirstTime", "text", "styles", "folders", "textScale", "currentLineIndex", "currentStyleId", "pastePointText", "ignoreLinePrefixes", "defaultStyleId", "shortcut", "language"];
+const storeFields = [
+  "notFirstTime",
+  "text",
+  "styles",
+  "folders",
+  "textScale",
+  "currentLineIndex",
+  "currentStyleId",
+  "pastePointText",
+  "ignoreLinePrefixes",
+  "defaultStyleId",
+  "shortcut",
+  "language",
+  "autoClosePsd",
+];
 
 const initialState = {
   notFirstTime: false,
@@ -25,6 +39,7 @@ const initialState = {
   modalType: null,
   modalData: {},
   images: [],
+  autoClosePsd: false,
   language: "auto",
   shortcut: {
     add: ["WIN", "CTRL"],
@@ -249,6 +264,11 @@ const reducer = (state, action) => {
 
   case "setLanguage": {
     newState.language = action.lang || "auto";
+    break;
+  }
+
+  case "setAutoClosePsd": {
+    newState.autoClosePsd = !!action.value;
     break;
   }
 

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -475,6 +475,7 @@ function _alignTextLayerToSelection() {
 
 var changeActiveLayerTextSizeVal;
 var changeActiveLayerTextSizeResult;
+var lastOpenedDocument;
 
 function _changeActiveLayerTextSize() {
   if (!documents.length) {
@@ -681,6 +682,14 @@ function changeActiveLayerTextSize(val) {
   return changeActiveLayerTextSizeResult;
 }
 
-function openFile(path) {
+function openFile(path, autoClose) {
+  if (autoClose && lastOpenedDocument && lastOpenedDocument.exists) {
+    try {
+      lastOpenedDocument.close(SaveOptions.DONOTSAVECHANGES);
+    } catch (e) {}
+  }
   app.open(File(path));
+  if (autoClose) {
+    lastOpenedDocument = app.activeDocument;
+  }
 }

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -299,8 +299,10 @@ const getDefaultStroke = () => {
   };
 };
 
-const openFile = (path) => {
-  csInterface.evalScript("openFile('" + path + "')");
+const openFile = (path, autoClose) => {
+  csInterface.evalScript(
+    "openFile('" + path + "', " + (!!autoClose) + ")"
+  );
 };
 
 export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Kein Style eingestellt
 settingsDefaultStyleDescr=(Optional) Wähle den Style aus welcher automatisch ausgewählt wird, wenn eine Zeile kein Tag hat.
 settingsLanguageLabel=Sprache
 settingsLanguageAuto=Automatisch
+settingsAutoClosePsdLabel=PSD automatisch schließen
 settingsImport=Alle Einstellungen und Stile importieren
 settingsExport=Alle Einstellungen und Stile exportieren
 settingsImportReplace=Möchten Sie Stile behalten, die beim Import fehlen oder ein späteres Bearbeitungsdatum haben?

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Sin estilo establecido
 settingsDefaultStyleDescr=(Opcional) Establezca el estilo, que se activará automáticamente al elegir una línea que no tenga etiqueta de estilo.
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
+settingsAutoClosePsdLabel=Cerrar PSD automáticamente
 settingsImport=Importar todas las configuraciones y estilos
 settingsExport=Exportar todas las configuraciones y estilos
 settingsImportReplace=¿Desea conservar los estilos que no están presentes en la importación o tienen una fecha de edición posterior?

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Aucun style défini
 settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquement activé quand une ligne sans marque est sélectionnée.
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
+settingsAutoClosePsdLabel=Fermeture automatique du PSD
 settingsImport=Importer tous les paramètres et styles
 settingsExport=Exporter tous les paramètres et styles
 settingsImportReplace=Voulez-vous conserver les styles qui manquent dans l’importation ou qui ont une date d’édition ultérieure?

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=No style set
 settingsDefaultStyleDescr=(Optional) Set the style, which will automatically become active when choosing a line which has no style tag.
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
+settingsAutoClosePsdLabel=Auto close PSD
 settingsImport=Import alll settings and styles
 settingsExport=Export all settings and styles
 settingsImportReplace=Do you want to keep styles that are not present in the import or have a later edit date?

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Sem conjunto de estilos
 settingsDefaultStyleDescr=(Opcional) Defina o estilo, que automaticamente se tornará ativo ao escolher uma linha que não tem tag de estilo.
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
+settingsAutoClosePsdLabel=Fechar PSD automaticamente
 settingsImport=Importar todas as configurações e estilos
 settingsExport=Exportar todas as configurações e estilos
 settingsImportReplace=Deseja manter os estilos que não estão presentes na importação ou ter uma data de edição posterior?

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -72,6 +72,7 @@ settingsDefaultStyleNone=Стиль не указан
 settingsDefaultStyleDescr=(Опционально) Укажите стиль, который будет автоматически становиться активным при выборе строки, у которой нет никаких префиксов стилей.
 settingsLanguageLabel=Язык
 settingsLanguageAuto=Авто
+settingsAutoClosePsdLabel=Автоматически закрывать PSD
 settingsImport=Импортировать все параметры и стили
 settingsExport=Экспортировать все параметры и стили
 settingsImportReplace=Хотите ли вы сохранить стили, которые отсутствуют в импорте или имеют более поздную дату редактирования?

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Stil seti yok
 settingsDefaultStyleDescr=(İsteğe bağlı) Stil etiketi olmayan bir satır seçildiğinde otomatik olarak etkinleşecek olan stili ayarlayın.
 settingsLanguageLabel=Dil
 settingsLanguageAuto=Otomatik
+settingsAutoClosePsdLabel=PSD'yi otomatik kapat
 settingsImport=Ayarları ve stilleri içe aktarın
 settingsExport=Ayarları ve stilleri dışa aktarın
 settingsImportReplace=İçe aktarmada bulunmayan veya düzenleme tarihi daha sonra olan stilleri saklamak istiyor musunuz?

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Стиль не вказано
 settingsDefaultStyleDescr=(Опціонально) Вкажіть стиль, який автоматично буде встановлюватись після вибору рядка, у якого немає префіксів стилю.
 settingsLanguageLabel=Мова
 settingsLanguageAuto=Авто
+settingsAutoClosePsdLabel=Автоматично закривати PSD
 settingsImport=Імпортувати всі налаштування та стилі
 settingsExport=Експортувати всі налаштування та стилі
 settingsImportReplace=Чи бажаєте зберегти стилі, які відсутні в імпортованих або мають пізнішу дату редагування?

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleNone=Không có kiểu cách nào được chọn
 settingsDefaultStyleDescr=(Tùy chọn) Lựa chọn kiểu cách sẽ được áp dụng tự động khi mà dòng được chọn không có ký hiệu chọn kiểu cách tự động.
 settingsLanguageLabel=Ngôn ngữ
 settingsLanguageAuto=Tự động
+settingsAutoClosePsdLabel=Tự động đóng PSD
 settingsImport=Nhập tất cả cài đặt và các kiểu
 settingsExport=Xuất tất cả cài đặt và các kiểu
 settingsImportReplace=Bạn có muốn giữ lại các kiểu cách chưa được lưu không? Các kiểu cách này không có trong tập tin hoặc có thể đã được chỉnh sửa mà chưa được xuất lại vào tập tin.


### PR DESCRIPTION
## Summary
- add `Auto close PSD` setting in context and settings modal
- close previous page automatically via host script
- update README with feature note
- update locale translations

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_684304d92618832f94fef5a25b681bc4