### PR TITLE
Add auto close PSD feature

### DIFF
--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -14,6 +14,9 @@ const SettingsModal = React.memo(function SettingsModal() {
   const [ignoreLinePrefixes, setIgnoreLinePrefixes] = React.useState(context.state.ignoreLinePrefixes.join(" "));
   const [defaultStyleId, setDefaultStyleId] = React.useState(context.state.defaultStyleId || "");
   const [language, setLanguage] = React.useState(context.state.language || "auto");
+  const [autoClosePSD, setAutoClosePSD] = React.useState(
+    !!context.state.autoClosePSD
+  );
   const [edited, setEdited] = React.useState(false);
 
   const close = () => {
@@ -37,6 +40,11 @@ const SettingsModal = React.memo(function SettingsModal() {
 
   const changeLanguage = (e) => {
     setLanguage(e.target.value);
+    setEdited(true);
+  };
+
+  const changeAutoClosePSD = (e) => {
+    setAutoClosePSD(e.target.checked);
     setEdited(true);
   };
 
@@ -66,6 +74,12 @@ const SettingsModal = React.memo(function SettingsModal() {
         lang: language,
       });
       setTimeout(() => window.location.reload(), 100);
+    }
+    if (autoClosePSD !== context.state.autoClosePSD) {
+      context.dispatch({
+        type: "setAutoClosePSD",
+        value: autoClosePSD,
+      });
     }
     const shortcut = {};
     document.querySelectorAll("input[id^=shortcut_]").forEach((input) => {
@@ -107,6 +121,7 @@ const SettingsModal = React.memo(function SettingsModal() {
         ignoreLinePrefixes: context.state.ignoreLinePrefixes,
         defaultStyleId: context.state.defaultStyleId,
         language: context.state.language,
+        autoClosePSD: context.state.autoClosePSD,
         textItemKind: context.state.setTextItemKind,
         folders: context.state.folders,
         styles: context.state.styles,
@@ -169,6 +184,15 @@ const SettingsModal = React.memo(function SettingsModal() {
                     </option>
                   ))}
                 </select>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsAutoClosePsdLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={autoClosePSD} onChange={changeAutoClosePSD} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
               </div>
             </div>
             <div className="field hostBrdTopContrast">

--- a/app_src/components/textBlock/textBlock.jsx
+++ b/app_src/components/textBlock/textBlock.jsx
@@ -42,7 +42,10 @@ const TextBlock = React.memo(function TextBlock() {
       return " ";
     }
     if (context.state.currentLineIndex === line.rawIndex && context.state.images[currentPage]) {
-      openFile(context.state.images[currentPage].path);
+      openFile(
+        context.state.images[currentPage].path,
+        context.state.autoClosePSD
+      );
     }
     return line.index;
   };

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -4,7 +4,21 @@ import { locale, readStorage, writeToStorage, scrollToLine, scrollToStyle, check
 import config from "./config";
 
 const storage = readStorage();
-const storeFields = ["notFirstTime", "text", "styles", "folders", "textScale", "currentLineIndex", "currentStyleId", "pastePointText", "ignoreLinePrefixes", "defaultStyleId", "shortcut", "language"];
+const storeFields = [
+  "notFirstTime",
+  "text",
+  "styles",
+  "folders",
+  "textScale",
+  "currentLineIndex",
+  "currentStyleId",
+  "pastePointText",
+  "ignoreLinePrefixes",
+  "defaultStyleId",
+  "autoClosePSD",
+  "shortcut",
+  "language",
+];
 
 const initialState = {
   notFirstTime: false,
@@ -22,6 +36,7 @@ const initialState = {
   pastePointText: false,
   ignoreLinePrefixes: ["##"],
   defaultStyleId: null,
+  autoClosePSD: false,
   modalType: null,
   modalData: {},
   images: [],
@@ -244,6 +259,11 @@ const reducer = (state, action) => {
 
   case "setPastePointText": {
     newState.pastePointText = !!action.isPoint;
+    break;
+  }
+
+  case "setAutoClosePSD": {
+    newState.autoClosePSD = !!action.value;
     break;
   }
 

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -476,6 +476,8 @@ function _alignTextLayerToSelection() {
 var changeActiveLayerTextSizeVal;
 var changeActiveLayerTextSizeResult;
 
+var _lastOpenedDocId = null;
+
 function _changeActiveLayerTextSize() {
   if (!documents.length) {
     changeActiveLayerTextSizeResult = "doc";
@@ -681,6 +683,20 @@ function changeActiveLayerTextSize(val) {
   return changeActiveLayerTextSizeResult;
 }
 
-function openFile(path) {
-  app.open(File(path));
+function openFile(path, autoClose) {
+  if (autoClose && _lastOpenedDocId !== null) {
+    for (var i = 0; i < app.documents.length; i++) {
+      var doc = app.documents[i];
+      if (doc.id === _lastOpenedDocId) {
+        try {
+          doc.close(SaveOptions.DONOTSAVECHANGES);
+        } catch (e) {}
+        break;
+      }
+    }
+  }
+  var newDoc = app.open(File(path));
+  if (autoClose) {
+    _lastOpenedDocId = newDoc.id;
+  }
 }

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -299,8 +299,10 @@ const getDefaultStroke = () => {
   };
 };
 
-const openFile = (path) => {
-  csInterface.evalScript("openFile('" + path + "')");
+const openFile = (path, autoClose = false) => {
+  csInterface.evalScript(
+    "openFile('" + path + "', " + (autoClose ? "true" : "false") + ")"
+  );
 };
 
 export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Kein Style eingestellt
 settingsDefaultStyleDescr=(Optional) Wähle den Style aus welcher automatisch ausgewählt wird, wenn eine Zeile kein Tag hat.
 settingsLanguageLabel=Sprache
 settingsLanguageAuto=Automatisch
+settingsAutoClosePsdLabel=PSD automatisch schließen
 settingsImport=Alle Einstellungen und Stile importieren
 settingsExport=Alle Einstellungen und Stile exportieren
 settingsImportReplace=Möchten Sie Stile behalten, die beim Import fehlen oder ein späteres Bearbeitungsdatum haben?

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Sin estilo establecido
 settingsDefaultStyleDescr=(Opcional) Establezca el estilo, que se activará automáticamente al elegir una línea que no tenga etiqueta de estilo.
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
+settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
 settingsImport=Importar todas las configuraciones y estilos
 settingsExport=Exportar todas las configuraciones y estilos
 settingsImportReplace=¿Desea conservar los estilos que no están presentes en la importación o tienen una fecha de edición posterior?

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Aucun style défini
 settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquement activé quand une ligne sans marque est sélectionnée.
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
+settingsAutoClosePsdLabel=Fermer automatiquement le PSD
 settingsImport=Importer tous les paramètres et styles
 settingsExport=Exporter tous les paramètres et styles
 settingsImportReplace=Voulez-vous conserver les styles qui manquent dans l’importation ou qui ont une date d’édition ultérieure?

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=No style set
 settingsDefaultStyleDescr=(Optional) Set the style, which will automatically become active when choosing a line which has no style tag.
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
+settingsAutoClosePsdLabel=Auto close PSD
 settingsImport=Import alll settings and styles
 settingsExport=Export all settings and styles
 settingsImportReplace=Do you want to keep styles that are not present in the import or have a later edit date?

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Sem conjunto de estilos
 settingsDefaultStyleDescr=(Opcional) Defina o estilo, que automaticamente se tornará ativo ao escolher uma linha que não tem tag de estilo.
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
+settingsAutoClosePsdLabel=Fechar PSD automaticamente
 settingsImport=Importar todas as configurações e estilos
 settingsExport=Exportar todas as configurações e estilos
 settingsImportReplace=Deseja manter os estilos que não estão presentes na importação ou ter uma data de edição posterior?

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -72,6 +72,7 @@ settingsDefaultStyleNone=Стиль не указан
 settingsDefaultStyleDescr=(Опционально) Укажите стиль, который будет автоматически становиться активным при выборе строки, у которой нет никаких префиксов стилей.
 settingsLanguageLabel=Язык
 settingsLanguageAuto=Авто
+settingsAutoClosePsdLabel=Автоматически закрывать PSD
 settingsImport=Импортировать все параметры и стили
 settingsExport=Экспортировать все параметры и стили
 settingsImportReplace=Хотите ли вы сохранить стили, которые отсутствуют в импорте или имеют более поздную дату редактирования?

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Stil seti yok
 settingsDefaultStyleDescr=(İsteğe bağlı) Stil etiketi olmayan bir satır seçildiğinde otomatik olarak etkinleşecek olan stili ayarlayın.
 settingsLanguageLabel=Dil
 settingsLanguageAuto=Otomatik
+settingsAutoClosePsdLabel=PSD'yi otomatik kapat
 settingsImport=Ayarları ve stilleri içe aktarın
 settingsExport=Ayarları ve stilleri dışa aktarın
 settingsImportReplace=İçe aktarmada bulunmayan veya düzenleme tarihi daha sonra olan stilleri saklamak istiyor musunuz?

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleNone=Стиль не вказано
 settingsDefaultStyleDescr=(Опціонально) Вкажіть стиль, який автоматично буде встановлюватись після вибору рядка, у якого немає префіксів стилю.
 settingsLanguageLabel=Мова
 settingsLanguageAuto=Авто
+settingsAutoClosePsdLabel=Автоматично закривати PSD
 settingsImport=Імпортувати всі налаштування та стилі
 settingsExport=Експортувати всі налаштування та стилі
 settingsImportReplace=Чи бажаєте зберегти стилі, які відсутні в імпортованих або мають пізнішу дату редагування?

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleNone=Không có kiểu cách nào được chọn
 settingsDefaultStyleDescr=(Tùy chọn) Lựa chọn kiểu cách sẽ được áp dụng tự động khi mà dòng được chọn không có ký hiệu chọn kiểu cách tự động.
 settingsLanguageLabel=Ngôn ngữ
 settingsLanguageAuto=Tự động
+settingsAutoClosePsdLabel=Tự động đóng PSD
 settingsImport=Nhập tất cả cài đặt và các kiểu
 settingsExport=Xuất tất cả cài đặt và các kiểu
 settingsImportReplace=Bạn có muốn giữ lại các kiểu cách chưa được lưu không? Các kiểu cách này không có trong tập tin hoặc có thể đã được chỉnh sửa mà chưa được xuất lại vào tập tin.


### PR DESCRIPTION
- add global `_lastOpenedDocId` tracking in host script
- update `openFile` implementation to close the previously opened file when enabled
- provide setting for auto closing PSDs
- export and store the new setting
- update locale files with new label translations