### PR TITLE
Refactor import/export workflow

### DIFF
--- a/app_src/components/footer/footer.jsx
+++ b/app_src/components/footer/footer.jsx
@@ -1,7 +1,7 @@
 import "./footer.scss";
 
 import React from "react";
-import { locale, nativeAlert, openFile } from "../../utils";
+import { locale, openFile } from "../../utils";
 import { useContext } from "../../context";
 
 const AppFooter = React.memo(function AppFooter() {
@@ -39,34 +39,6 @@ const AppFooter = React.memo(function AppFooter() {
     }
   };
 
-  const importStyleFolder = () => {
-    const pathSelect = window.cep.fs.showOpenDialogEx(false, false, null, null, ["json"]);
-    if (!pathSelect?.data?.[0]) return false;
-    const result = window.cep.fs.readFile(pathSelect.data[0]);
-    if (result.err) {
-      nativeAlert(locale.errorImportStyles, locale.errorTitle, true);
-    } else {
-      try {
-        const folder = JSON.parse(result.data);
-        if (!folder) {
-          nativeAlert(locale.errorFolderCreation, locale.errorTitle, true);
-          return false;
-        }
-        const dataFolder = { name: folder.name };
-        dataFolder.id = Math.random().toString(36).substring(2, 8);
-        context.dispatch({ type: "saveFolder", data: dataFolder });
-        const exportedStyles = folder.exportedStyles;
-        exportedStyles.forEach((style) => {
-          const dataStyle = { name: style.name, folder: dataFolder.id, textProps: style.textProps };
-          dataStyle.id = Math.random().toString(36).substring(2, 8);
-          dataStyle.edited = Date.now();
-          context.dispatch({ type: "saveStyle", data: dataStyle });
-        });
-      } catch (error) {
-        nativeAlert(locale.errorImportStyles, locale.errorTitle, true);
-      }
-    }
-  };
   return (
     <React.Fragment>
       <span className="link" onClick={openHelp}>
@@ -77,9 +49,6 @@ const AppFooter = React.memo(function AppFooter() {
       </span>
       <span className="link" onClick={openRepository}>
         {locale.footerOpenRepo}
-      </span>
-      <span className="link link-left" onClick={importStyleFolder}>
-        {locale.footerImportStyleFolder}
       </span>
     </React.Fragment>
   );

--- a/app_src/components/modal/export.jsx
+++ b/app_src/components/modal/export.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { FiX } from "react-icons/fi";
+import { MdSave } from "react-icons/md";
+
+import config from "../../config";
+import { locale } from "../../utils";
+import { useContext } from "../../context";
+
+const ExportModal = React.memo(function ExportModal() {
+  const context = useContext();
+  const [selected, setSelected] = React.useState([]);
+  const [withSettings, setWithSettings] = React.useState(true);
+
+  const close = () => {
+    context.dispatch({ type: "setModal" });
+  };
+
+  const toggleFolder = (id, checked) => {
+    let arr = selected.slice();
+    if (checked) arr.push(id);
+    else arr = arr.filter((fid) => fid !== id);
+    setSelected(arr);
+  };
+
+  const exportData = (e) => {
+    e.preventDefault();
+    if (!selected.length && !withSettings) return;
+    const pathSelect = window.cep.fs.showSaveDialogEx(
+      false,
+      false,
+      ["json"],
+      config.exportFileName + ".json"
+    );
+    if (!pathSelect?.data) return false;
+    const folders = context.state.folders.filter((f) => selected.includes(f.id));
+    const styles = context.state.styles.filter((s) => selected.includes(s.folder));
+    const data = {
+      folders,
+      styles,
+      version: config.appVersion,
+      exported: new Date(),
+    };
+    if (withSettings) {
+      data.ignoreLinePrefixes = context.state.ignoreLinePrefixes;
+      data.defaultStyleId = context.state.defaultStyleId;
+      data.language = context.state.language;
+      data.autoClosePSD = context.state.autoClosePSD;
+      data.textItemKind = context.state.setTextItemKind;
+    }
+    window.cep.fs.writeFile(pathSelect.data, JSON.stringify(data));
+    close();
+  };
+
+  return (
+    <React.Fragment>
+      <div className="app-modal-header hostBrdBotContrast">
+        <div className="app-modal-title">{locale.settingsExport}</div>
+        <button className="topcoat-icon-button--large--quiet" title={locale.close} onClick={close}>
+          <FiX size={18} />
+        </button>
+      </div>
+      <div className="app-modal-body">
+        <form className="app-modal-body-inner" onSubmit={exportData}>
+          <div className="fields">
+            {context.state.folders.map((folder) => (
+              <label key={folder.id} className="topcoat-checkbox export-folder-item">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(folder.id)}
+                  onChange={(e) => toggleFolder(folder.id, e.target.checked)}
+                />
+                <div className="topcoat-checkbox__checkmark"></div>
+                <div className="export-folder-title">{folder.name}</div>
+              </label>
+            ))}
+            <label className="topcoat-checkbox export-settings-item">
+              <input
+                type="checkbox"
+                checked={withSettings}
+                onChange={(e) => setWithSettings(e.target.checked)}
+              />
+              <div className="topcoat-checkbox__checkmark"></div>
+              <div className="export-settings-title">{locale.exportIncludeSettings}</div>
+            </label>
+          </div>
+          <div className="fields hostBrdTopContrast">
+            <button type="submit" className="topcoat-button--large--cta">
+              <MdSave size={18} /> {locale.save}
+            </button>
+          </div>
+        </form>
+      </div>
+    </React.Fragment>
+  );
+});
+
+export default ExportModal;

--- a/app_src/components/modal/modal.jsx
+++ b/app_src/components/modal/modal.jsx
@@ -6,6 +6,7 @@ import HelpModal from './help';
 import SettingsModal from './settings';
 import EditStyleModal from './editStyle';
 import EditFolderModal from './editFolder';
+import ExportModal from './export';
 import UpdateModal from './update';
 
 
@@ -18,6 +19,7 @@ const Modal = React.memo(function Modal() {
     else if (modalType === 'settings') modalContent = <SettingsModal />;
     else if (modalType === 'editStyle') modalContent = <EditStyleModal />;
     else if (modalType === 'editFolder') modalContent = <EditFolderModal />;
+    else if (modalType === 'export') modalContent = <ExportModal />;
     else if (modalType === 'update') modalContent = <UpdateModal />;
 
     React.useEffect(() => {

--- a/app_src/components/modal/modal.scss
+++ b/app_src/components/modal/modal.scss
@@ -55,3 +55,17 @@
     font-size: 12px;
     flex: 0 0 auto;
 }
+
+.export-folder-item,
+.export-settings-item {
+    display: flex;
+    align-items: center;
+    padding: 4px;
+}
+.export-folder-item + .export-folder-item {
+    margin-top: 4px;
+}
+.export-folder-title,
+.export-settings-title {
+    margin-left: 6px;
+}

--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -95,40 +95,43 @@ const SettingsModal = React.memo(function SettingsModal() {
   };
 
   const importSettings = () => {
-    const pathSelect = window.cep.fs.showOpenDialogEx(false, false, null, null, ["json"]);
-    if (!pathSelect?.data?.[0]) return false;
-    const result = window.cep.fs.readFile(pathSelect.data[0]);
-    if (result.err) {
-      nativeAlert(locale.errorImportStyles, locale.errorTitle, true);
-    } else {
-      try {
-        const data = JSON.parse(result.data);
-        context.dispatch({ type: "import", data });
-        setTimeout(() => window.location.reload(), 100);
-        close();
-      } catch (error) {
+    const pathSelect = window.cep.fs.showOpenDialogEx(true, false, null, null, ["json"]);
+    if (!pathSelect?.data?.length) return false;
+    pathSelect.data.forEach((path) => {
+      const result = window.cep.fs.readFile(path);
+      if (result.err) {
         nativeAlert(locale.errorImportStyles, locale.errorTitle, true);
+      } else {
+        try {
+          const data = JSON.parse(result.data);
+          if (data.exportedStyles) {
+            const dataFolder = { name: data.name };
+            dataFolder.id = Math.random().toString(36).substring(2, 8);
+            context.dispatch({ type: "saveFolder", data: dataFolder });
+            data.exportedStyles.forEach((style) => {
+              const dataStyle = {
+                name: style.name,
+                folder: dataFolder.id,
+                textProps: style.textProps,
+              };
+              dataStyle.id = Math.random().toString(36).substring(2, 8);
+              dataStyle.edited = Date.now();
+              context.dispatch({ type: "saveStyle", data: dataStyle });
+            });
+          } else {
+            context.dispatch({ type: "import", data });
+            setTimeout(() => window.location.reload(), 100);
+            close();
+          }
+        } catch (error) {
+          nativeAlert(locale.errorImportStyles, locale.errorTitle, true);
+        }
       }
-    }
+    });
   };
 
   const exportSettings = () => {
-    const pathSelect = window.cep.fs.showSaveDialogEx(false, false, ["json"], config.exportFileName + ".json");
-    if (!pathSelect?.data) return false;
-    window.cep.fs.writeFile(
-      pathSelect.data,
-      JSON.stringify({
-        ignoreLinePrefixes: context.state.ignoreLinePrefixes,
-        defaultStyleId: context.state.defaultStyleId,
-        language: context.state.language,
-        autoClosePSD: context.state.autoClosePSD,
-        textItemKind: context.state.setTextItemKind,
-        folders: context.state.folders,
-        styles: context.state.styles,
-        version: config.appVersion,
-        exported: new Date(),
-      })
-    );
+    context.dispatch({ type: "setModal", modal: "export" });
   };
 
   return (

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -74,8 +74,9 @@ settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquemen
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
 settingsAutoClosePsdLabel=Fermer automatiquement le PSD
-settingsImport=Importer tous les paramètres et styles
-settingsExport=Exporter tous les paramètres et styles
+settingsImport=Importer des styles ou paramètres
+settingsExport=Exporter des styles ou paramètres
+exportIncludeSettings=Exporter mes paramètres
 settingsImportReplace=Voulez-vous conserver les styles qui manquent dans l’importation ou qui ont une date d’édition ultérieure?
 
 ## edit style

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -74,8 +74,9 @@ settingsDefaultStyleDescr=(Optional) Set the style, which will automatically bec
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
 settingsAutoClosePsdLabel=Auto close PSD
-settingsImport=Import alll settings and styles
-settingsExport=Export all settings and styles
+settingsImport=Import styles or settings
+settingsExport=Export styles or settings
+exportIncludeSettings=Export my settings
 settingsImportReplace=Do you want to keep styles that are not present in the import or have a later edit date?
 
 ## edit style


### PR DESCRIPTION
## Summary
- drop style folder import from footer and centralize logic in settings import
- extend settings import to also load style folders
- switch settings export to open a new Export modal
- implement export modal with folder selection and optional settings export
- adjust modal styles for export UI
- update English and French locale strings

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_684387ca799c832fab89581d32050c92