### PR TITLE
Add option for automatic update checks

### DIFF
--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -4,7 +4,7 @@ import { MdSave } from "react-icons/md";
 import { FaFileExport, FaFileImport } from "react-icons/fa";
 
 import config from "../../config";
-import { locale, nativeAlert } from "../../utils";
+import { locale, nativeAlert, checkUpdate } from "../../utils";
 import { useContext } from "../../context";
 import Shortcut from "./shortCut";
 
@@ -16,6 +16,9 @@ const SettingsModal = React.memo(function SettingsModal() {
   const [language, setLanguage] = React.useState(context.state.language || "auto");
   const [autoClosePSD, setAutoClosePSD] = React.useState(
     !!context.state.autoClosePSD
+  );
+  const [checkUpdates, setCheckUpdates] = React.useState(
+    context.state.checkUpdates !== false
   );
   const [edited, setEdited] = React.useState(false);
 
@@ -45,6 +48,11 @@ const SettingsModal = React.memo(function SettingsModal() {
 
   const changeAutoClosePSD = (e) => {
     setAutoClosePSD(e.target.checked);
+    setEdited(true);
+  };
+
+  const changeCheckUpdates = (e) => {
+    setCheckUpdates(e.target.checked);
     setEdited(true);
   };
 
@@ -79,6 +87,12 @@ const SettingsModal = React.memo(function SettingsModal() {
       context.dispatch({
         type: "setAutoClosePSD",
         value: autoClosePSD,
+      });
+    }
+    if (checkUpdates !== context.state.checkUpdates) {
+      context.dispatch({
+        type: "setCheckUpdates",
+        value: checkUpdates,
       });
     }
     const shortcut = {};
@@ -183,6 +197,16 @@ const SettingsModal = React.memo(function SettingsModal() {
     context.dispatch({ type: "setModal", modal: "export" });
   };
 
+  const checkUpdatesNow = () => {
+    checkUpdate(config.appVersion).then((data) => {
+      if (data) {
+        context.dispatch({ type: "setModal", modal: "update", data });
+      } else {
+        nativeAlert(locale.updateNoUpdate, locale.successTitle, false);
+      }
+    });
+  };
+
   return (
     <React.Fragment>
       <div className="app-modal-header hostBrdBotContrast">
@@ -248,6 +272,15 @@ const SettingsModal = React.memo(function SettingsModal() {
               </div>
             </div>
             <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsCheckUpdatesLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={checkUpdates} onChange={changeCheckUpdates} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
               <div className="field-label">{locale.shortcut}</div>
               {Object.entries(context.state.shortcut).map(([index, value]) => (
                 <Shortcut value={value} index={index}></Shortcut>
@@ -268,6 +301,11 @@ const SettingsModal = React.memo(function SettingsModal() {
             <div className="field">
               <button className="topcoat-button--large" onClick={exportSettings}>
                 <FaFileExport size={18} /> {locale.settingsExport}
+              </button>
+            </div>
+            <div className="field">
+              <button className="topcoat-button--large" onClick={checkUpdatesNow}>
+                {locale.settingsCheckUpdatesButton}
               </button>
             </div>
           </div>

--- a/app_src/config.js
+++ b/app_src/config.js
@@ -6,6 +6,7 @@ const config = {
   authorUrl: "https://discord.gg/dsHn3xQQTC",
   exportFileName: "TypeR_Export",
   defaultPrefixColor: "#FFF3B0",
+  checkUpdates: true,
   languages: {
     auto: "Auto",
     en_US: "English",

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -16,6 +16,7 @@ const storeFields = [
   "ignoreLinePrefixes",
   "defaultStyleId",
   "autoClosePSD",
+  "checkUpdates",
   "images",
   "shortcut",
   "language",
@@ -38,6 +39,7 @@ const initialState = {
   ignoreLinePrefixes: ["##"],
   defaultStyleId: null,
   autoClosePSD: false,
+  checkUpdates: config.checkUpdates,
   modalType: null,
   modalData: {},
   images: [],
@@ -268,6 +270,11 @@ const reducer = (state, action) => {
     break;
   }
 
+  case "setCheckUpdates": {
+    newState.checkUpdates = !!action.value;
+    break;
+  }
+
   case "setLanguage": {
     newState.language = action.lang || "auto";
     break;
@@ -406,12 +413,14 @@ const ContextProvider = React.memo(function ContextProvider(props) {
   const [state, dispatch] = React.useReducer(reducer, initialState);
   React.useEffect(() => dispatch({}), []);
   React.useEffect(() => {
-    checkUpdate(config.appVersion).then((data) => {
-      if (data) {
-        dispatch({ type: 'setModal', modal: 'update', data });
-      }
-    });
-  }, []);
+    if (state.checkUpdates) {
+      checkUpdate(config.appVersion).then((data) => {
+        if (data) {
+          dispatch({ type: 'setModal', modal: 'update', data });
+        }
+      });
+    }
+  }, [state.checkUpdates]);
   return <Context.Provider value={{ state, dispatch }}>{props.children}</Context.Provider>;
 });
 ContextProvider.propTypes = {

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -74,6 +74,8 @@ settingsDefaultStyleDescr=(Optional) Wähle den Style aus welcher automatisch au
 settingsLanguageLabel=Sprache
 settingsLanguageAuto=Automatisch
 settingsAutoClosePsdLabel=PSD automatisch schließen
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Alle Einstellungen und Stile importieren
 settingsExport=Alle Einstellungen und Stile exportieren
 settingsImportReplace=Möchten Sie Stile behalten, die beim Import fehlen oder ein späteres Bearbeitungsdatum haben?
@@ -191,4 +193,5 @@ updateTitle=Update verfügbar
 updateText=Version {version} ist verfügbar.
 updateDownload=Herunterladen
 updateChanges=Änderungsprotokoll
+updateNoUpdate=You are running the latest version.
 

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -74,6 +74,8 @@ settingsDefaultStyleDescr=(Opcional) Establezca el estilo, que se activará auto
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Importar todas las configuraciones y estilos
 settingsExport=Exportar todas las configuraciones y estilos
 settingsImportReplace=¿Desea conservar los estilos que no están presentes en la importación o tienen una fecha de edición posterior?
@@ -191,4 +193,5 @@ updateTitle=Actualización disponible
 updateText=Versión {version} disponible.
 updateDownload=Descargar
 updateChanges=Registro de cambios
+updateNoUpdate=You are running the latest version.
 

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -75,6 +75,8 @@ settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquemen
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
 settingsAutoClosePsdLabel=Fermer automatiquement le PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Importer des styles ou paramètres
 settingsExport=Exporter des styles ou paramètres
 exportIncludeSettings=Exporter mes paramètres
@@ -196,4 +198,5 @@ updateTitle=Mise à jour disponible
 updateText=La version {version} de TypeR est disponible !
 updateDownload=Télécharger
 updateChanges=Journal des modifications
+updateNoUpdate=You are running the latest version.
 

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -75,6 +75,8 @@ settingsDefaultStyleDescr=(Optional) Set the style, which will automatically bec
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
 settingsAutoClosePsdLabel=Auto close PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Import styles or settings
 settingsExport=Export styles or settings
 exportIncludeSettings=Export my settings
@@ -196,4 +198,5 @@ updateTitle=Update available
 updateText=Version {version} of TypeR is available!
 updateDownload=Download
 updateChanges=Changelog
+updateNoUpdate=You are running the latest version.
 

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -74,6 +74,8 @@ settingsDefaultStyleDescr=(Opcional) Defina o estilo, que automaticamente se tor
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Fechar PSD automaticamente
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Importar todas as configurações e estilos
 settingsExport=Exportar todas as configurações e estilos
 settingsImportReplace=Deseja manter os estilos que não estão presentes na importação ou ter uma data de edição posterior?
@@ -191,4 +193,5 @@ updateTitle=Atualização disponível
 updateText=Versão {version} disponível.
 updateDownload=Baixar
 updateChanges=Registro de alterações
+updateNoUpdate=You are running the latest version.
 

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -73,6 +73,8 @@ settingsDefaultStyleDescr=(Опционально) Укажите стиль, к
 settingsLanguageLabel=Язык
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматически закрывать PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Импортировать все параметры и стили
 settingsExport=Экспортировать все параметры и стили
 settingsImportReplace=Хотите ли вы сохранить стили, которые отсутствуют в импорте или имеют более поздную дату редактирования?
@@ -190,4 +192,5 @@ updateTitle=Доступно обновление
 updateText=Доступна версия {version}.
 updateDownload=Скачать
 updateChanges=Список изменений
+updateNoUpdate=You are running the latest version.
 

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -74,6 +74,8 @@ settingsDefaultStyleDescr=(İsteğe bağlı) Stil etiketi olmayan bir satır se�
 settingsLanguageLabel=Dil
 settingsLanguageAuto=Otomatik
 settingsAutoClosePsdLabel=PSD yi otomatik kapat
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Ayarları ve stilleri içe aktarın
 settingsExport=Ayarları ve stilleri dışa aktarın
 settingsImportReplace=İçe aktarmada bulunmayan veya düzenleme tarihi daha sonra olan stilleri saklamak istiyor musunuz?
@@ -191,4 +193,5 @@ updateTitle=Güncelleme mevcut
 updateText={version} sürümü mevcut.
 updateDownload=İndir
 updateChanges=Değişiklik listesi
+updateNoUpdate=You are running the latest version.
 

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -74,6 +74,8 @@ settingsDefaultStyleDescr=(Опціонально) Вкажіть стиль, я
 settingsLanguageLabel=Мова
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматично закривати PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Імпортувати всі налаштування та стилі
 settingsExport=Експортувати всі налаштування та стилі
 settingsImportReplace=Чи бажаєте зберегти стилі, які відсутні в імпортованих або мають пізнішу дату редагування?
@@ -191,4 +193,5 @@ updateTitle=Доступне оновлення
 updateText=Доступна версія {version}.
 updateDownload=Завантажити
 updateChanges=Список змін
+updateNoUpdate=You are running the latest version.
 

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -75,6 +75,8 @@ settingsDefaultStyleDescr=(Tùy chọn) Lựa chọn kiểu cách sẽ được 
 settingsLanguageLabel=Ngôn ngữ
 settingsLanguageAuto=Tự động
 settingsAutoClosePsdLabel=Tự động đóng PSD
+settingsCheckUpdatesLabel=Check for updates automatically
+settingsCheckUpdatesButton=Check for updates
 settingsImport=Nhập tất cả cài đặt và các kiểu
 settingsExport=Xuất tất cả cài đặt và các kiểu
 settingsImportReplace=Bạn có muốn giữ lại các kiểu cách chưa được lưu không? Các kiểu cách này không có trong tập tin hoặc có thể đã được chỉnh sửa mà chưa được xuất lại vào tập tin.
@@ -192,4 +194,5 @@ updateTitle=Có bản cập nhật
 updateText=Phiên bản {version} đã có sẵn.
 updateDownload=Tải về
 updateChanges=Nhật ký thay đổi
+updateNoUpdate=You are running the latest version.
 


### PR DESCRIPTION
- add a `checkUpdates` option in config
- store and expose `checkUpdates` in context
- let users toggle update checks in settings
- allow manual update check from Settings modal
- show message when no update is found