### PR TITLE
Add minimal view option

### DIFF
--- a/app_src/components/footer/footer.scss
+++ b/app_src/components/footer/footer.scss
@@ -24,3 +24,10 @@
     display: none;
   }
 }
+
+.minimal-view .footer-block {
+  display: flex;
+}
+.minimal-view .footer-block .link:not(:nth-child(2)) {
+  display: none;
+}

--- a/app_src/components/main/main.jsx
+++ b/app_src/components/main/main.jsx
@@ -2,6 +2,7 @@ import "./main.scss";
 
 import React from "react";
 import { readStorage, writeToStorage, resizeTextArea } from "../../utils";
+import { useContext } from "../../context";
 import Modal from "../modal/modal";
 import TextBlock from "../textBlock/textBlock";
 import PreviewBlock from "../previewBlock/previewBlock";
@@ -13,6 +14,7 @@ const minMiddleHeight = 100;
 const minBottomHeight = 70;
 
 const ResizeableCont = React.memo(function ResizeableCont() {
+  const context = useContext();
   const appBlock = React.useRef();
   const bottomBlock = React.useRef();
 
@@ -45,7 +47,8 @@ const ResizeableCont = React.memo(function ResizeableCont() {
   };
 
   const setBottomSize = (height) => {
-    const maxBottomHeight = appHeight - (appHeight > 450 ? topHeight : 0) - minMiddleHeight;
+    const maxBottomHeight =
+      appHeight - (appHeight > 450 && !context.state.minimalView ? topHeight : 0) - minMiddleHeight;
     bottomHeight = height || readStorage("bottomHeight") || minBottomHeight;
     if (height < minBottomHeight) bottomHeight = minBottomHeight;
     if (height > maxBottomHeight) bottomHeight = maxBottomHeight;
@@ -65,7 +68,13 @@ const ResizeableCont = React.memo(function ResizeableCont() {
   }, []);
 
   return (
-    <div className="app-body" ref={appBlock} onMouseMove={moveBottomResize} onMouseLeave={stopBottomResize} onMouseUp={stopBottomResize}>
+    <div
+      className={"app-body" + (context.state.minimalView ? " minimal-view" : "")}
+      ref={appBlock}
+      onMouseMove={moveBottomResize}
+      onMouseLeave={stopBottomResize}
+      onMouseUp={stopBottomResize}
+    >
       <Modal />
       <div className="top-block preview-block" style={{ height: topHeight }}>
         <PreviewBlock />

--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -17,6 +17,7 @@ const SettingsModal = React.memo(function SettingsModal() {
   const [autoClosePSD, setAutoClosePSD] = React.useState(
     !!context.state.autoClosePSD
   );
+  const [minimalView, setMinimalView] = React.useState(!!context.state.minimalView);
   const [edited, setEdited] = React.useState(false);
 
   const close = () => {
@@ -45,6 +46,11 @@ const SettingsModal = React.memo(function SettingsModal() {
 
   const changeAutoClosePSD = (e) => {
     setAutoClosePSD(e.target.checked);
+    setEdited(true);
+  };
+
+  const changeMinimalView = (e) => {
+    setMinimalView(e.target.checked);
     setEdited(true);
   };
 
@@ -79,6 +85,12 @@ const SettingsModal = React.memo(function SettingsModal() {
       context.dispatch({
         type: "setAutoClosePSD",
         value: autoClosePSD,
+      });
+    }
+    if (minimalView !== context.state.minimalView) {
+      context.dispatch({
+        type: "setMinimalView",
+        value: minimalView,
       });
     }
     const shortcut = {};
@@ -243,6 +255,15 @@ const SettingsModal = React.memo(function SettingsModal() {
               <div className="field-input">
                 <label className="topcoat-checkbox">
                   <input type="checkbox" checked={autoClosePSD} onChange={changeAutoClosePSD} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsMinimalLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={minimalView} onChange={changeMinimalView} />
                   <div className="topcoat-checkbox__checkmark"></div>
                 </label>
               </div>

--- a/app_src/components/previewBlock/previewBlock.scss
+++ b/app_src/components/previewBlock/previewBlock.scss
@@ -146,3 +146,7 @@
     display: none;
   }
 }
+
+.minimal-view .preview-block {
+  display: none;
+}

--- a/app_src/components/stylesBlock/stylesBlock.scss
+++ b/app_src/components/stylesBlock/stylesBlock.scss
@@ -188,3 +188,7 @@
     display: none;
   }
 }
+
+.minimal-view .styles-block {
+  display: none;
+}

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -16,6 +16,7 @@ const storeFields = [
   "ignoreLinePrefixes",
   "defaultStyleId",
   "autoClosePSD",
+  "minimalView",
   "images",
   "shortcut",
   "language",
@@ -38,6 +39,7 @@ const initialState = {
   ignoreLinePrefixes: ["##"],
   defaultStyleId: null,
   autoClosePSD: false,
+  minimalView: false,
   modalType: null,
   modalData: {},
   images: [],
@@ -265,6 +267,11 @@ const reducer = (state, action) => {
 
   case "setAutoClosePSD": {
     newState.autoClosePSD = !!action.value;
+    break;
+  }
+
+  case "setMinimalView": {
+    newState.minimalView = !!action.value;
     break;
   }
 

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleDescr=(Optional) Wähle den Style aus welcher automatisch au
 settingsLanguageLabel=Sprache
 settingsLanguageAuto=Automatisch
 settingsAutoClosePsdLabel=PSD automatisch schließen
+settingsMinimalLabel=Minimalansicht
 settingsImport=Alle Einstellungen und Stile importieren
 settingsExport=Alle Einstellungen und Stile exportieren
 settingsImportReplace=Möchten Sie Stile behalten, die beim Import fehlen oder ein späteres Bearbeitungsdatum haben?

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleDescr=(Opcional) Establezca el estilo, que se activará auto
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
+settingsMinimalLabel=Vista mínima
 settingsImport=Importar todas las configuraciones y estilos
 settingsExport=Exportar todas las configuraciones y estilos
 settingsImportReplace=¿Desea conservar los estilos que no están presentes en la importación o tienen una fecha de edición posterior?

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -75,6 +75,7 @@ settingsDefaultStyleDescr=(Facultatif) Définir le style qui sera automatiquemen
 settingsLanguageLabel=Langue
 settingsLanguageAuto=Automatique
 settingsAutoClosePsdLabel=Fermer automatiquement le PSD
+settingsMinimalLabel=Mode minimaliste
 settingsImport=Importer des styles ou paramètres
 settingsExport=Exporter des styles ou paramètres
 exportIncludeSettings=Exporter mes paramètres

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -75,6 +75,7 @@ settingsDefaultStyleDescr=(Optional) Set the style, which will automatically bec
 settingsLanguageLabel=Language
 settingsLanguageAuto=Auto
 settingsAutoClosePsdLabel=Auto close PSD
+settingsMinimalLabel=Minimal view
 settingsImport=Import styles or settings
 settingsExport=Export styles or settings
 exportIncludeSettings=Export my settings

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleDescr=(Opcional) Defina o estilo, que automaticamente se tor
 settingsLanguageLabel=Idioma
 settingsLanguageAuto=Automático
 settingsAutoClosePsdLabel=Fechar PSD automaticamente
+settingsMinimalLabel=Visualização mínima
 settingsImport=Importar todas as configurações e estilos
 settingsExport=Exportar todas as configurações e estilos
 settingsImportReplace=Deseja manter os estilos que não estão presentes na importação ou ter uma data de edição posterior?

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -73,6 +73,7 @@ settingsDefaultStyleDescr=(Опционально) Укажите стиль, к
 settingsLanguageLabel=Язык
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматически закрывать PSD
+settingsMinimalLabel=Минимальный режим
 settingsImport=Импортировать все параметры и стили
 settingsExport=Экспортировать все параметры и стили
 settingsImportReplace=Хотите ли вы сохранить стили, которые отсутствуют в импорте или имеют более поздную дату редактирования?

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleDescr=(İsteğe bağlı) Stil etiketi olmayan bir satır se�
 settingsLanguageLabel=Dil
 settingsLanguageAuto=Otomatik
 settingsAutoClosePsdLabel=PSD yi otomatik kapat
+settingsMinimalLabel=Minimal görünüm
 settingsImport=Ayarları ve stilleri içe aktarın
 settingsExport=Ayarları ve stilleri dışa aktarın
 settingsImportReplace=İçe aktarmada bulunmayan veya düzenleme tarihi daha sonra olan stilleri saklamak istiyor musunuz?

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -74,6 +74,7 @@ settingsDefaultStyleDescr=(Опціонально) Вкажіть стиль, я
 settingsLanguageLabel=Мова
 settingsLanguageAuto=Авто
 settingsAutoClosePsdLabel=Автоматично закривати PSD
+settingsMinimalLabel=Мінімальний режим
 settingsImport=Імпортувати всі налаштування та стилі
 settingsExport=Експортувати всі налаштування та стилі
 settingsImportReplace=Чи бажаєте зберегти стилі, які відсутні в імпортованих або мають пізнішу дату редагування?

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -75,6 +75,7 @@ settingsDefaultStyleDescr=(Tùy chọn) Lựa chọn kiểu cách sẽ được 
 settingsLanguageLabel=Ngôn ngữ
 settingsLanguageAuto=Tự động
 settingsAutoClosePsdLabel=Tự động đóng PSD
+settingsMinimalLabel=Chế độ tối giản
 settingsImport=Nhập tất cả cài đặt và các kiểu
 settingsExport=Xuất tất cả cài đặt và các kiểu
 settingsImportReplace=Bạn có muốn giữ lại các kiểu cách chưa được lưu không? Các kiểu cách này không có trong tập tin hoặc có thể đã được chỉnh sửa mà chưa được xuất lại vào tập tin.


### PR DESCRIPTION
## Summary
- add `minimalView` to context state and reducer
- hide preview, styles and adjust footer in minimal view mode
- allow toggling minimal mode from settings
- update translation files

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447b22c6e8832f9b48c57f6e2b9f1e