### PR TITLE
Support bold markup in textBlock

### DIFF
--- a/app_src/components/previewBlock/previewBlock.jsx
+++ b/app_src/components/previewBlock/previewBlock.jsx
@@ -6,7 +6,7 @@ import { FiArrowRightCircle, FiPlusCircle, FiMinusCircle, FiArrowUp, FiArrowDown
 import { AiOutlineBorderInner } from "react-icons/ai";
 import { MdCenterFocusWeak } from "react-icons/md";
 
-import { locale, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getStyleObject, scrollToLine } from "../../utils";
+import { locale, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getStyleObject, scrollToLine, removeBoldMarkup } from "../../utils";
 import { useContext } from "../../context";
 
 const PreviewBlock = React.memo(function PreviewBlock() {
@@ -29,7 +29,7 @@ const PreviewBlock = React.memo(function PreviewBlock() {
       }
     }
     const pointText = context.state.pastePointText;
-    createTextLayerInSelection(line.text, lineStyle, pointText, (ok) => {
+    createTextLayerInSelection(removeBoldMarkup(line.text), lineStyle, pointText, (ok) => {
       if (ok) context.dispatch({ type: "nextLine", add: true });
     });
   };
@@ -46,7 +46,7 @@ const PreviewBlock = React.memo(function PreviewBlock() {
         txtStyle.leading *= context.state.textScale / 100;
       }
     }
-    setActiveLayerText(line.text, lineStyle, (ok) => {
+    setActiveLayerText(removeBoldMarkup(line.text), lineStyle, (ok) => {
       if (ok) context.dispatch({ type: "nextLine", add: true });
     });
   };

--- a/app_src/components/textBlock/textBlock.jsx
+++ b/app_src/components/textBlock/textBlock.jsx
@@ -4,8 +4,15 @@ import React from "react";
 import { FiArrowRightCircle, FiTarget } from "react-icons/fi";
 
 import config from "../../config";
-import { locale, setActiveLayerText, resizeTextArea, scrollToLine, openFile } from "../../utils";
+import { locale, setActiveLayerText, resizeTextArea, scrollToLine, openFile, removeBoldMarkup } from "../../utils";
 import { useContext } from "../../context";
+
+const parseBoldMarkup = (text) => {
+  const parts = text.split(/\*\*(.*?)\*\*/g);
+  return parts.map((part, idx) =>
+    idx % 2 ? <strong key={idx}>{part}</strong> : <React.Fragment key={idx}>{part}</React.Fragment>
+  );
+};
 
 const TextBlock = React.memo(function TextBlock() {
   const context = useContext();
@@ -81,17 +88,17 @@ const TextBlock = React.memo(function TextBlock() {
               {line.ignorePrefix ? (
                 <React.Fragment>
                   <span className="text-line-ignore-prefix">{line.ignorePrefix}</span>
-                  <span>{line.rawText.replace(line.ignorePrefix, "")}</span>
+                  <span>{parseBoldMarkup(line.rawText.replace(line.ignorePrefix, ""))}</span>
                 </React.Fragment>
               ) : line.stylePrefix ? (
                 <React.Fragment>
                   <span className="text-line-style-prefix" style={{ background: line.style?.prefixColor || config.defaultPrefixColor }}>
                     {line.stylePrefix}
                   </span>
-                  <span>{line.rawText.replace(line.stylePrefix, "")}</span>
+                  <span>{parseBoldMarkup(line.rawText.replace(line.stylePrefix, ""))}</span>
                 </React.Fragment>
               ) : (
-                <span>{line.rawText || " "}</span>
+                <span>{parseBoldMarkup(line.rawText || " ")}</span>
               )}
             </div>
             <div className="text-line-insert" title={line.ignore ? "" : locale.insertText}>
@@ -99,7 +106,7 @@ const TextBlock = React.memo(function TextBlock() {
                 <FiArrowRightCircle
                   size={14}
                   onClick={() => {
-                    setActiveLayerText(line.text);
+                    setActiveLayerText(removeBoldMarkup(line.text));
                     context.dispatch({ type: "nextLine", add: true });
                   }}
                 />

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import React from "react";
 
-import { csInterface, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, getHotkeyPressed, changeActiveLayerTextSize } from "./utils";
+import { csInterface, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, getHotkeyPressed, changeActiveLayerTextSize, removeBoldMarkup } from "./utils";
 import { useContext } from "./context";
 
 const CTRL = "CTRL";
@@ -70,7 +70,7 @@ const HotkeysListner = React.memo(function HotkeysListner() {
           txtStyle.leading *= context.state.textScale / 100;
         }
       }
-      setActiveLayerText(line.text, style, (ok) => {
+      setActiveLayerText(removeBoldMarkup(line.text), style, (ok) => {
         if (ok) context.dispatch({ type: "nextLine", add: true });
       });
     } else if (checkShortcut(realState, context.state.shortcut.center)) {

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -306,4 +306,6 @@ const openFile = (path, autoClose = false) => {
   );
 };
 
-export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };
+const removeBoldMarkup = (text) => text.replace(/\*\*(.*?)\*\*/g, "$1");
+
+export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate, removeBoldMarkup };


### PR DESCRIPTION
## Summary
- parse `**bold**` markup in `textBlock` lines and render with `<strong>`
- strip bold markup before inserting lines into Photoshop
- share a `removeBoldMarkup` helper via `utils`
- update hotkeys and preview block to remove bold markup on insert

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d4c9b004832fb8b23a35bcf2e877