### PR TITLE
Fix page navigation when no images

### DIFF
--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -363,7 +363,7 @@ const reducer = (state, action) => {
     const text = rawText.replace(ignorePrefix, "").replace(stylePrefix, "").trim();
     const isPage = rawText.match(/Page [0-9]+/);
     const ignore = !!ignorePrefix || !text || isPage;
-    if (isPage) {
+    if (isPage && newState.images.length) {
       last.push(linesCounter);
     }
     const index = ignore ? 0 : ++linesCounter;


### PR DESCRIPTION
- avoid marking end-of-page lines as the last line when no pages are imported