### PR TITLE
Fix style stroke

### DIFF
--- a/app_src/components/modal/editStyle.jsx
+++ b/app_src/components/modal/editStyle.jsx
@@ -86,7 +86,8 @@ const EditStyleModal = React.memo(function EditStyleModal() {
   };
 
   const changeStrokeSize = (e) => {
-    setStroke({ ...stroke, size: parseFloat(e.target.value) || 0 });
+    const size = parseFloat(e.target.value) || 0;
+    setStroke({ ...stroke, size, enabled: size > 0 });
     setEdited(true);
   };
 
@@ -101,7 +102,14 @@ const EditStyleModal = React.memo(function EditStyleModal() {
       nativeAlert(locale.errorStyleCreation, locale.errorTitle, true);
       return false;
     }
-    const data = { name, folder, textProps, prefixes, prefixColor, stroke };
+    const data = {
+      name,
+      folder,
+      textProps,
+      prefixes,
+      prefixColor,
+      stroke: { ...stroke, enabled: stroke.size > 0 },
+    };
     if (currentData.create) {
       data.id = Math.random().toString(36).substr(2, 8);
     } else {

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -207,7 +207,7 @@ function _getLayerStroke() {
  *                          position is forced to "outer".
  */
 function _setLayerStroke(stroke) {
-  if (!stroke || stroke.enabled === false) return;
+  if (!stroke || stroke.enabled === false || !stroke.size) return;
 
   var d = new ActionDescriptor();
   var r = new ActionReference();


### PR DESCRIPTION
## Summary
- enable strokes when setting non-zero size
- ensure strokes remain enabled when styles are saved
- ignore zero-sized strokes in host script

## Testing
- `npm run build` *(fails: rimraf: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846030351cc832fb4a8d02235280fe2