### PR TITLE
Automatic update install

### DIFF
--- a/app_src/components/modal/update.jsx
+++ b/app_src/components/modal/update.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FiX } from 'react-icons/fi';
 
-import { locale, openUrl } from '../../utils';
+import { locale, installUpdate } from '../../utils';
 import { useContext } from '../../context';
 
 const UpdateModal = React.memo(function UpdateModal() {
@@ -11,7 +11,7 @@ const UpdateModal = React.memo(function UpdateModal() {
     context.dispatch({ type: 'setModal' });
   };
   const download = () => {
-    openUrl('https://github.com/ScanR/TypeR/releases/latest');
+    installUpdate();
     close();
   };
   return (

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -34,10 +34,10 @@ const installUpdate = async () => {
 
     const arrayBuffer = await response.arrayBuffer();
 
-    const fs = require('fs');
-    const os = require('os');
-    const pathMod = require('path');
-    const { execSync, spawnSync } = require('child_process');
+    const fs = window.require('fs');
+    const os = window.require('os');
+    const pathMod = window.require('path');
+    const { execSync, spawnSync } = window.require('child_process');
 
     const tmp = pathMod.join(os.tmpdir(), 'typer_update');
     if (!fs.existsSync(tmp)) fs.mkdirSync(tmp, { recursive: true });

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Textgröße Verkleinern
 ## update
 updateTitle=Update verfügbar
 updateText=Version {version} ist verfügbar.
-updateDownload=Herunterladen
+updateDownload=Installieren
 updateChanges=Änderungsprotokoll
 updateNoUpdate=You are running the latest version.
 

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Disminuir Tamaño del Texto
 ## update
 updateTitle=Actualización disponible
 updateText=Versión {version} disponible.
-updateDownload=Descargar
+updateDownload=Instalar
 updateChanges=Registro de cambios
 updateNoUpdate=You are running the latest version.
 

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Diminuer taille du texte
 ## update
 updateTitle=Mise à jour disponible
 updateText=La version {version} de TypeR est disponible !
-updateDownload=Télécharger
+updateDownload=Installer
 updateChanges=Journal des modifications
 updateNoUpdate=You are running the latest version.
 

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Decrease text size
 ## update
 updateTitle=Update available
 updateText=Version {version} of TypeR is available!
-updateDownload=Download
+updateDownload=Install
 updateChanges=Changelog
 updateNoUpdate=You are running the latest version.
 

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Diminuir Tamanho do Texto
 ## update
 updateTitle=Atualização disponível
 updateText=Versão {version} disponível.
-updateDownload=Baixar
+updateDownload=Instalar
 updateChanges=Registro de alterações
 updateNoUpdate=You are running the latest version.
 

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -197,7 +197,7 @@ shortcut_decrease=Уменьшить Размер Текста
 ## update
 updateTitle=Доступно обновление
 updateText=Доступна версия {version}.
-updateDownload=Скачать
+updateDownload=Установить
 updateChanges=Список изменений
 updateNoUpdate=You are running the latest version.
 

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Yazı Boyutunu Azalt
 ## update
 updateTitle=Güncelleme mevcut
 updateText={version} sürümü mevcut.
-updateDownload=İndir
+updateDownload=Yükle
 updateChanges=Değişiklik listesi
 updateNoUpdate=You are running the latest version.
 

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -198,7 +198,7 @@ shortcut_decrease=Зменшити Розмір Тексту
 ## update
 updateTitle=Доступне оновлення
 updateText=Доступна версія {version}.
-updateDownload=Завантажити
+updateDownload=Встановити
 updateChanges=Список змін
 updateNoUpdate=You are running the latest version.
 

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -199,7 +199,7 @@ shortcut_decrease=Giảm Kích Thước Văn Bản
 ## update
 updateTitle=Có bản cập nhật
 updateText=Phiên bản {version} đã có sẵn.
-updateDownload=Tải về
+updateDownload=Cài đặt
 updateChanges=Nhật ký thay đổi
 updateNoUpdate=You are running the latest version.
 


### PR DESCRIPTION
## Summary
- change update button to trigger automatic installation
- implement `installUpdate` utility to download the latest release zip, extract and run the platform installer
- add translated button labels for installing updates

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465a0aa150832f8fafb2ae649a4c73