### PR TITLE
Allow mapping side mouse buttons to shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TypeR is a better version of TyperTools, a Photoshop extension designed for type
 - **Stable Auto-Centering**: Text shape no longer changes when using auto-centering.
 - **Auto-centering** now works without manual selection by automatically detecting the bubble shape (like in Typesetterer).
 - **Customizable Shortcuts**: You can now modify keyboard shortcuts. (+ added some new keyboard shortcuts)
-- **Mouse Shortcuts**: Side mouse buttons can be mapped to commands and work even when the panel isn't focused.
+- **Mouse Shortcuts**: Side mouse buttons can be mapped to commands and now trigger even if the TypeR panel isn't focused.
 - **Automatic Page Detection**: Automatically detects pages when importing.
 - **Automatic Page Switching**: Automatically switches pages for seamless workflow.  
 - **Resize TypeR**: Decreased size limit of the TypeR window so it can be much smaller.  

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ TypeR is a better version of TyperTools, a Photoshop extension designed for type
 - Added **stroke (outline)** support to styles.
 - **Stable Auto-Centering**: Text shape no longer changes when using auto-centering.
 - **Auto-centering** now works without manual selection by automatically detecting the bubble shape (like in Typesetterer).
-- **Customizable Shortcuts**: You can now modify keyboard shortcuts. (+ added some new keyboard shortcuts)  
-- **Automatic Page Detection**: Automatically detects pages when importing.  
+- **Customizable Shortcuts**: You can now modify keyboard shortcuts. (+ added some new keyboard shortcuts)
+- **Mouse Shortcuts**: Side mouse buttons can be mapped to commands and work even when the panel isn't focused.
+- **Automatic Page Detection**: Automatically detects pages when importing.
 - **Automatic Page Switching**: Automatically switches pages for seamless workflow.  
 - **Resize TypeR**: Decreased size limit of the TypeR window so it can be much smaller.  
 - **Line Spacing Sync**: When increasing/decreasing text size with TypeR, line spacing adjusts accordingly.  

--- a/app_src/components/modal/shortCut.jsx
+++ b/app_src/components/modal/shortCut.jsx
@@ -17,6 +17,13 @@ const Shortcut = (props) => {
     if (e.shiftKey) {
       shortCut += `${shortCut ? " + " : ""}SHIFT`;
     }
+    if (e.button !== undefined) {
+      if (e.button === 3) {
+        shortCut += `${shortCut ? " + " : ""}BUTTON4`;
+      } else if (e.button === 4) {
+        shortCut += `${shortCut ? " + " : ""}BUTTON5`;
+      }
+    }
     if (e.key && !["Meta", "Control", "Alt", "Shift"].includes(e.key)) {
       if (e.key === "+") {
         shortCut += `${shortCut ? " + " : ""}PLUS`;
@@ -39,7 +46,13 @@ const Shortcut = (props) => {
     <React.Fragment key={props.index}>
       <div className="field-mini-label">{locale[`shortcut_${props.index}`]}</div>
       <div className="field-input">
-        <input id={`shortcut_${props.index}`} value={props.value.join(" + ")} onKeyDown={changeShortCut} className="topcoat-textarea" />
+        <input
+          id={`shortcut_${props.index}`}
+          value={props.value.join(" + ")}
+          onKeyDown={changeShortCut}
+          onMouseDown={changeShortCut}
+          className="topcoat-textarea"
+        />
       </div>
     </React.Fragment>
   );

--- a/app_src/components/modal/shortCut.jsx
+++ b/app_src/components/modal/shortCut.jsx
@@ -3,6 +3,9 @@ import { locale } from "../../utils";
 
 const Shortcut = (props) => {
   const changeShortCut = (e) => {
+    if (e.type === "mousedown" && e.button !== 3 && e.button !== 4) {
+      return;
+    }
     e.preventDefault();
     let shortCut = "";
     if (e.metaKey) {

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -671,12 +671,18 @@ function getHotkeyPressed() {
     string += "SHIFTa";
   }
   if (state.keyName) {
-    string += state.keyName.toUpperCase() + "a";
-  }
-  if (mouse.button !== undefined) {
-    if (mouse.button == 4 || mouse.buttonName == "Button 4") {
+    var key = state.keyName;
+    if (key === "BrowserBack" || key === "Button 4") {
       string += "BUTTON4a";
-    } else if (mouse.button == 5 || mouse.buttonName == "Button 5") {
+    } else if (key === "BrowserForward" || key === "Button 5") {
+      string += "BUTTON5a";
+    } else {
+      string += key.toUpperCase() + "a";
+    }
+  } else if (mouse.button !== undefined) {
+    if (mouse.button == 3 || mouse.buttonName == "Button 4") {
+      string += "BUTTON4a";
+    } else if (mouse.button == 4 || mouse.buttonName == "Button 5") {
       string += "BUTTON5a";
     }
   }

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -655,6 +655,7 @@ function getUserFonts() {
 
 function getHotkeyPressed() {
   var state = ScriptUI.environment.keyboardState;
+  var mouse = ScriptUI.environment.mouseState;
   var string = "a";
 
   if (state.metaKey) {
@@ -668,6 +669,13 @@ function getHotkeyPressed() {
   }
   if (state.shiftKey) {
     string += "SHIFTa";
+  }
+  if (mouse && mouse.buttonName) {
+    if (mouse.buttonName === "Button 4") {
+      string += "BUTTON4a";
+    } else if (mouse.buttonName === "Button 5") {
+      string += "BUTTON5a";
+    }
   }
   if (state.keyName) {
     string += state.keyName.toUpperCase() + "a";

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -655,7 +655,6 @@ function getUserFonts() {
 
 function getHotkeyPressed() {
   var state = ScriptUI.environment.keyboardState;
-  var mouse = ScriptUI.environment.mouseState;
   var string = "a";
 
   if (state.metaKey) {
@@ -669,13 +668,6 @@ function getHotkeyPressed() {
   }
   if (state.shiftKey) {
     string += "SHIFTa";
-  }
-  if (mouse && mouse.buttonName) {
-    if (mouse.buttonName === "Button 4") {
-      string += "BUTTON4a";
-    } else if (mouse.buttonName === "Button 5") {
-      string += "BUTTON5a";
-    }
   }
   if (state.keyName) {
     string += state.keyName.toUpperCase() + "a";

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -655,6 +655,7 @@ function getUserFonts() {
 
 function getHotkeyPressed() {
   var state = ScriptUI.environment.keyboardState;
+  var mouse = ScriptUI.environment.mouseState || {};
   var string = "a";
 
   if (state.metaKey) {
@@ -671,6 +672,13 @@ function getHotkeyPressed() {
   }
   if (state.keyName) {
     string += state.keyName.toUpperCase() + "a";
+  }
+  if (mouse.button !== undefined) {
+    if (mouse.button == 4 || mouse.buttonName == "Button 4") {
+      string += "BUTTON4a";
+    } else if (mouse.button == 5 || mouse.buttonName == "Button 5") {
+      string += "BUTTON5a";
+    }
   }
   return string;
 }

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -16,8 +16,6 @@ const intervalTime = 50;
 let keyboardInterval = 0;
 let canRepeat = true;
 let keyUp = true;
-let mouseButtons = [];
-let mouseDown = false;
 
 const checkRepeatTime = (time = repeatTime) => {
   if (canRepeat && keyUp) {
@@ -38,6 +36,7 @@ const checkShortcut = (state, ref) => {
 
 const handleMouseDown = (e, callback) => {
   if (e.button !== 3 && e.button !== 4) return;
+  e.preventDefault();
   const keys = [];
   if (e.metaKey) keys.push(WIN);
   if (e.ctrlKey) keys.push(CTRL);

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -8,12 +8,16 @@ const CTRL = "CTRL";
 const SHIFT = "SHIFT";
 const ALT = "ALT";
 const WIN = "WIN";
+const BUTTON4 = "BUTTON4";
+const BUTTON5 = "BUTTON5";
 
 const repeatTime = 2000;
 const intervalTime = 50;
 let keyboardInterval = 0;
 let canRepeat = true;
 let keyUp = true;
+let mouseButtons = [];
+let mouseDown = false;
 
 const checkRepeatTime = (time = repeatTime) => {
   if (canRepeat && keyUp) {
@@ -30,6 +34,19 @@ const checkRepeatTime = (time = repeatTime) => {
 
 const checkShortcut = (state, ref) => {
   return ref.every((key) => state.includes(key));
+};
+
+const handleMouseDown = (e, callback) => {
+  if (e.button !== 3 && e.button !== 4) return;
+  const keys = [];
+  if (e.metaKey) keys.push(WIN);
+  if (e.ctrlKey) keys.push(CTRL);
+  if (e.altKey) keys.push(ALT);
+  if (e.shiftKey) keys.push(SHIFT);
+  if (e.button === 3) keys.push(BUTTON4);
+  if (e.button === 4) keys.push(BUTTON5);
+  const state = "a" + keys.join("a") + "a";
+  callback(state);
 };
 
 const HotkeysListner = React.memo(function HotkeysListner() {
@@ -106,6 +123,14 @@ const HotkeysListner = React.memo(function HotkeysListner() {
       }
     }
   };
+
+  React.useEffect(() => {
+    const listener = (e) => {
+      handleMouseDown(e, checkState);
+    };
+    document.addEventListener("mousedown", listener);
+    return () => document.removeEventListener("mousedown", listener);
+  }, [context.state]);
 
   React.useEffect(() => {
     const keyInterests = [{ keyCode: 27 }];


### PR DESCRIPTION
## Summary
- allow recording mouse button 4 & 5 when editing shortcuts
- detect side mouse buttons in Photoshop host
- react to mouse button presses when panel is focused