### PR TITLE
Add clipboard paste support

### DIFF
--- a/app_src/components/previewBlock/previewBlock.jsx
+++ b/app_src/components/previewBlock/previewBlock.jsx
@@ -2,11 +2,11 @@ import "./previewBlock.scss";
 
 import _ from "lodash";
 import React from "react";
-import { FiArrowRightCircle, FiPlusCircle, FiMinusCircle, FiArrowUp, FiArrowDown } from "react-icons/fi";
+import { FiArrowRightCircle, FiPlusCircle, FiMinusCircle, FiArrowUp, FiArrowDown, FiClipboard } from "react-icons/fi";
 import { AiOutlineBorderInner } from "react-icons/ai";
 import { MdCenterFocusWeak } from "react-icons/md";
 
-import { locale, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getStyleObject, scrollToLine } from "../../utils";
+import { locale, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getStyleObject, scrollToLine, pasteFromClipboard } from "../../utils";
 import { useContext } from "../../context";
 
 const PreviewBlock = React.memo(function PreviewBlock() {
@@ -34,7 +34,7 @@ const PreviewBlock = React.memo(function PreviewBlock() {
     });
   };
 
-  const insertStyledText = () => {
+const insertStyledText = () => {
     let lineStyle = context.state.currentStyle;
     if (lineStyle && context.state.textScale) {
       lineStyle = _.cloneDeep(lineStyle);
@@ -47,6 +47,12 @@ const PreviewBlock = React.memo(function PreviewBlock() {
       }
     }
     setActiveLayerText(line.text, lineStyle, (ok) => {
+      if (ok) context.dispatch({ type: "nextLine", add: true });
+    });
+  };
+
+  const pasteClipboard = () => {
+    pasteFromClipboard(line.text, (ok) => {
       if (ok) context.dispatch({ type: "nextLine", add: true });
     });
   };
@@ -102,8 +108,9 @@ const PreviewBlock = React.memo(function PreviewBlock() {
                 <span>%</span>
               </div>
             </div>
-            <div className="preview-line-info-actions" title={locale.insertStyledText}>
-              <FiArrowRightCircle size={16} onClick={insertStyledText} />
+            <div className="preview-line-info-actions">
+              <FiClipboard size={16} title={locale.pasteClipboard} onClick={pasteClipboard} />
+              <FiArrowRightCircle size={16} title={locale.insertStyledText} onClick={insertStyledText} />
             </div>
           </div>
           <div className="preview-line-text" style={styleObject} dangerouslySetInnerHTML={{ __html: `<span style='font-family: "${styleObject.fontFamily || "Tahoma"}"'>${line.text || ""}</span>` }}></div>

--- a/app_src/components/previewBlock/previewBlock.scss
+++ b/app_src/components/previewBlock/previewBlock.scss
@@ -126,6 +126,9 @@
   & > SVG {
     cursor: pointer;
     opacity: 0.7;
+    &:not(:first-child) {
+      margin-left: 4px;
+    }
     &:hover {
       color: #fff;
       opacity: 1;

--- a/app_src/components/textBlock/textBlock.jsx
+++ b/app_src/components/textBlock/textBlock.jsx
@@ -1,10 +1,10 @@
 import "./textBlock.scss";
 
 import React from "react";
-import { FiArrowRightCircle, FiTarget } from "react-icons/fi";
+import { FiArrowRightCircle, FiTarget, FiClipboard } from "react-icons/fi";
 
 import config from "../../config";
-import { locale, setActiveLayerText, resizeTextArea, scrollToLine, openFile } from "../../utils";
+import { locale, setActiveLayerText, resizeTextArea, scrollToLine, openFile, pasteFromClipboard } from "../../utils";
 import { useContext } from "../../context";
 
 const TextBlock = React.memo(function TextBlock() {
@@ -94,15 +94,29 @@ const TextBlock = React.memo(function TextBlock() {
                 <span>{line.rawText || " "}</span>
               )}
             </div>
-            <div className="text-line-insert" title={line.ignore ? "" : locale.insertText}>
-              {line.ignore ? " " : (
-                <FiArrowRightCircle
-                  size={14}
-                  onClick={() => {
-                    setActiveLayerText(line.text);
-                    context.dispatch({ type: "nextLine", add: true });
-                  }}
-                />
+            <div className="text-line-insert">
+              {line.ignore ? (
+                " "
+              ) : (
+                <>
+                  <FiClipboard
+                    size={14}
+                    title={locale.pasteClipboard}
+                    onClick={() => {
+                      pasteFromClipboard(line.text, () => {
+                        context.dispatch({ type: "nextLine", add: true });
+                      });
+                    }}
+                  />
+                  <FiArrowRightCircle
+                    size={14}
+                    title={locale.insertText}
+                    onClick={() => {
+                      setActiveLayerText(line.text);
+                      context.dispatch({ type: "nextLine", add: true });
+                    }}
+                  />
+                </>
               )}
             </div>
           </div>

--- a/app_src/components/textBlock/textBlock.scss
+++ b/app_src/components/textBlock/textBlock.scss
@@ -127,18 +127,21 @@
 .text-line-insert {
   text-align: center;
   flex: 0 0 auto;
-  width: 20px;
+  width: 34px;
   & > SVG {
     margin-bottom: -5px;
     position: relative;
     cursor: pointer;
     top: -2px;
-    &:hover {
-      color: #000;
-    }
-    .text-line.m-current &:hover {
-      color: #073357;
-    }
+  }
+  & > SVG + SVG {
+    margin-left: 4px;
+  }
+  & > SVG:hover {
+    color: #000;
+  }
+  .text-line.m-current & > SVG:hover {
+    color: #073357;
   }
 }
 .text-area {

--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -48,6 +48,7 @@ const initialState = {
     add: ["WIN", "CTRL"],
     center: ["WIN", "ALT"],
     apply: ["WIN", "SHIFT"],
+    editPaste: ["WIN", "V"],
     next: ["CTRL", "ENTER"],
     previous: ["CTRL", "TAB"],
     increase: ["CTRL", "SHIFT", "PLUS"],

--- a/app_src/host.js
+++ b/app_src/host.js
@@ -728,3 +728,13 @@ function openFile(path, autoClose) {
     _lastOpenedDocId = newDoc.id;
   }
 }
+
+function pasteFromClipboard() {
+  if (!documents.length) {
+    return "doc";
+  } else if (activeDocument.activeLayer.kind != LayerKind.TEXT) {
+    return "layer";
+  }
+  executeAction(charIDToTypeID("past"), new ActionDescriptor(), DialogModes.NO);
+  return "";
+}

--- a/app_src/hotkeys.jsx
+++ b/app_src/hotkeys.jsx
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import React from "react";
 
-import { csInterface, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, getHotkeyPressed, changeActiveLayerTextSize } from "./utils";
+import { csInterface, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, getHotkeyPressed, changeActiveLayerTextSize, pasteFromClipboard } from "./utils";
 import { useContext } from "./context";
 
 const CTRL = "CTRL";
@@ -71,6 +71,12 @@ const HotkeysListner = React.memo(function HotkeysListner() {
         }
       }
       setActiveLayerText(line.text, style, (ok) => {
+        if (ok) context.dispatch({ type: "nextLine", add: true });
+      });
+    } else if (checkShortcut(realState, context.state.shortcut.editPaste)) {
+      if (!checkRepeatTime()) return;
+      const line = context.state.currentLine || { text: "" };
+      pasteFromClipboard(line.text, (ok) => {
         if (ok) context.dispatch({ type: "nextLine", add: true });
       });
     } else if (checkShortcut(realState, context.state.shortcut.center)) {

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -179,6 +179,16 @@ const changeActiveLayerTextSize = (val, callback = () => {}) => {
   });
 };
 
+const pasteFromClipboard = async (text, callback = () => {}) => {
+  try {
+    await navigator.clipboard.writeText(text || "");
+  } catch (e) {}
+  csInterface.evalScript("pasteFromClipboard()", (error) => {
+    if (error) nativeAlert(locale.errorNoTextLayer, locale.errorTitle, true);
+    callback(!error);
+  });
+};
+
 const getHotkeyPressed = (callback) => {
   csInterface.evalScript("getHotkeyPressed()", callback);
 };
@@ -306,4 +316,4 @@ const openFile = (path, autoClose = false) => {
   );
 };
 
-export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };
+export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, pasteFromClipboard, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -153,6 +153,7 @@ previewLine=Zeile
 previewStyle=Style
 previewTextScale=Skala
 insertStyledText=Wende den Text und den Style auf das ausgewählte Layer an (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Klicken Sie, um den Text bis zu dieser Zeile zu scrollen
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Nächste Zeile
 shortcut_previous=Vorherige Zeile
 shortcut_increase=Textgröße Vergrößern
 shortcut_decrease=Textgröße Verkleinern
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Update verfügbar

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -153,6 +153,7 @@ previewLine=Línea
 previewStyle=Estilo
 previewTextScale=Escala
 insertStyledText=Aplicar el texto y el estilo a la capa actual (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Haga clic para desplazar el texto a esta línea
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Línea Siguiente
 shortcut_previous=Línea Anterior
 shortcut_increase=Aumentar Tamaño del Texto
 shortcut_decrease=Disminuir Tamaño del Texto
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Actualización disponible

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -153,6 +153,7 @@ previewLine=ligne 
 previewStyle=style 
 previewTextScale=échelle 
 insertStyledText=Appliquer le texte et le style au calque actuel (Win + Maj)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Cliquez pour défiler jusqu’à cette ligne dans le bloc de texte
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Ligne suivante
 shortcut_previous=Ligne précédente
 shortcut_increase=Augmenter taille du texte
 shortcut_decrease=Diminuer taille du texte
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Mise à jour disponible

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -153,6 +153,7 @@ previewLine=line
 previewStyle=style
 previewTextScale=scale
 insertStyledText=Apply the text and the style to the current layer (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Click to scroll the text to this line
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Next line
 shortcut_previous=Previous line
 shortcut_increase=Increase text size
 shortcut_decrease=Decrease text size
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Update available

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -153,6 +153,7 @@ previewLine=Linha
 previewStyle=Estilo
 previewTextScale=Escala
 insertStyledText=Aplicar o texto e o estilo à camada atual (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Clique para rolar o texto para esta linha
 
 ## bloco de texto
@@ -194,6 +195,7 @@ shortcut_next=Próxima Linha
 shortcut_previous=Linha Anterior
 shortcut_increase=Aumentar Tamanho do Texto
 shortcut_decrease=Diminuir Tamanho do Texto
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Atualização disponível

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -152,6 +152,7 @@ previewLine=строка
 previewStyle=стиль
 previewTextScale=масштаб
 insertStyledText=Применить текст и стиль к текущему слою (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Нажмите, чтобы прокрутить текст до этой строки
 
 ## text block
@@ -193,6 +194,7 @@ shortcut_next=Следующая Строка
 shortcut_previous=Предыдущая Строка
 shortcut_increase=Увеличить Размер Текста
 shortcut_decrease=Уменьшить Размер Текста
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Доступно обновление

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -153,6 +153,7 @@ previewLine=satır
 previewStyle=stil
 previewTextScale=ölçek
 insertStyledText=Metni ve stili geçerli katmana uygula (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Metni bu satıra kaydırmak için tıklayın
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Sonraki Satır
 shortcut_previous=Önceki Satır
 shortcut_increase=Yazı Boyutunu Artır
 shortcut_decrease=Yazı Boyutunu Azalt
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Güncelleme mevcut

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -153,6 +153,7 @@ previewLine=Рядок
 previewStyle=Стиль
 previewTextScale=Масштаб
 insertStyledText=Застосувати текст і стиль до активного шару (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Натисніть, щоб прокрутити текст до цього рядка
 
 ## text block
@@ -194,6 +195,7 @@ shortcut_next=Наступний Рядок
 shortcut_previous=Попередній Рядок
 shortcut_increase=Збільшити Розмір Тексту
 shortcut_decrease=Зменшити Розмір Тексту
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Доступне оновлення

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -154,6 +154,7 @@ previewLine=Dòng
 previewStyle=Kiểu cách
 previewTextScale=Độ thu phóng
 insertStyledText=Áp dụng văn bản và kiểu cách cho lớp đang chọn (Win + Shift)
+pasteClipboard=Paste text into the active layer (Win + V)
 scrollToLine=Nhấp chuột để cuộn vùng văn bản tới dòng này
 
 ## vùng văn bản
@@ -195,6 +196,7 @@ shortcut_next=Dòng Tiếp Theo
 shortcut_previous=Dòng Trước
 shortcut_increase=Tăng Kích Thước Văn Bản
 shortcut_decrease=Giảm Kích Thước Văn Bản
+shortcut_editPaste=Paste text
 
 ## update
 updateTitle=Có bản cập nhật


### PR DESCRIPTION
## Summary
- add host command `pasteFromClipboard` to paste into active layer
- expose `pasteFromClipboard` util and call from preview/text blocks
- handle new `editPaste` shortcut in hotkeys
- show clipboard paste option in UI and settings
- add locale strings for clipboard paste action

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c33b8a88832f809b9321a49c7ec5