### PR TITLE
Add multi-paste support

### DIFF
--- a/app_src/context.jsx
+++ b/app_src/context.jsx
@@ -133,12 +133,16 @@ const reducer = (state, action) => {
     case "nextLine": {
       if (!state.text || (action.add && newState.currentLine.last)) break;
       let newIndex = state.currentLineIndex;
-      for (let i = newIndex + 1; i < state.lines.length; i++) {
-        if (!state.lines[i].ignore) {
-          newState.currentLineIndex = state.lines[i].rawIndex;
-          break;
+      const count = action.count || 1;
+      for (let c = 0; c < count; c++) {
+        for (let i = newIndex + 1; i < state.lines.length; i++) {
+          if (!state.lines[i].ignore) {
+            newIndex = state.lines[i].rawIndex;
+            break;
+          }
         }
       }
+      newState.currentLineIndex = newIndex;
       thenScroll = true;
       thenSelectStyle = true;
       break;

--- a/app_src/utils.js
+++ b/app_src/utils.js
@@ -164,6 +164,21 @@ const createTextLayerInSelection = (text, style, pointText, callback = () => {})
   });
 };
 
+/**
+ * Pose autant de calques texte qu’il y a de sous-sélections.
+ * @param {string[]} lines — les lignes à insérer
+ * @param {Object}   lineStyle — style (peut être null)
+ * @param {boolean}  pointText — true ⇒ point-text, false ⇒ box-text
+ * @param {Function} cb — callback(ok)
+ */
+const createTextLayersInSelections = (lines, lineStyle, pointText, cb) => {
+  const payload = { lines, style: lineStyle };
+  csInterface.evalScript(
+    `createTextLayersInSelections(${JSON.stringify(payload)}, ${!!pointText})`,
+    (res) => cb && cb(res === "")
+  );
+};
+
 const alignTextLayerToSelection = () => {
   csInterface.evalScript("alignTextLayerToSelection()", (error) => {
     if (error === "smallSelection") nativeAlert(locale.errorSmallSelection, locale.errorTitle, true);
@@ -306,4 +321,4 @@ const openFile = (path, autoClose = false) => {
   );
 };
 
-export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };
+export { csInterface, locale, openUrl, readStorage, writeToStorage, nativeAlert, nativeConfirm, getUserFonts, getActiveLayerText, setActiveLayerText, createTextLayerInSelection, createTextLayersInSelections, alignTextLayerToSelection, changeActiveLayerTextSize, getHotkeyPressed, resizeTextArea, scrollToLine, scrollToStyle, rgbToHex, getStyleObject, getDefaultStyle, getDefaultStroke, openFile, checkUpdate };


### PR DESCRIPTION
## Summary
- add helper for retrieving multiple selections
- implement multi-paste functions in host
- expose multi-selection paste API to React side
- update preview block to use new multi-paste logic
- allow skipping multiple lines in reducer when creating multiple layers

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850edfbd0f8832faed57d343c0004c7