### PR TITLE
Fix font style selection

### DIFF
--- a/app_src/components/modal/editStyle.jsx
+++ b/app_src/components/modal/editStyle.jsx
@@ -274,6 +274,11 @@ const StyleDetails = React.memo(function StyleDetails(props) {
     const newProps = _.cloneDeep(props.textProps);
     const newStyle = newProps.layerText.textStyleRange[0].textStyle;
     newStyle.fontStyleName = style;
+    const font = fonts.find((f) => f.family === family && f.style === style);
+    if (font) {
+      newStyle.fontPostScriptName = font.postScriptName;
+      newStyle.fontName = font.name;
+    }
     props.setTextProps(newProps);
   };
 


### PR DESCRIPTION
## Summary
- ensure font style dropdown updates the font's PostScript name so selected weight is applied correctly

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626a647b88832f85eaa854ab9433d2