### PR TITLE
Fix missing themes in packaged extension

### DIFF
--- a/install_mac.sh
+++ b/install_mac.sh
@@ -147,7 +147,7 @@ fi
 rm -rf "${DESTDIR}"
 mkdir -p "${DESTDIR}"
 
-for item in app CSXS icons locale .debug; do
+for item in app CSXS icons locale themes .debug; do
   if [ -e "${SRCDIR}/${item}" ]; then
     cp -rf "${SRCDIR}/${item}" "${DESTDIR}/${item}"
   fi

--- a/install_win.cmd
+++ b/install_win.cmd
@@ -70,6 +70,7 @@ xcopy app "%Directory%\app\" /E/Y
 xcopy CSXS "%Directory%\CSXS\" /E/Y
 xcopy icons "%Directory%\icons\" /E/Y
 xcopy locale "%Directory%\locale\" /E/Y
+xcopy themes "%Directory%\themes\" /E/Y
 if exist .debug copy .debug "%Directory%\.debug" /Y
 if exist __storage (
     copy __storage "%Directory%\storage" /Y

--- a/pack.zip.ps1
+++ b/pack.zip.ps1
@@ -13,6 +13,7 @@ New-Item -Type Dir .\\$name\\app
 New-Item -Type Dir .\\$name\\CSXS
 New-Item -Type Dir .\\$name\\icons
 New-Item -Type Dir .\\$name\\locale
+New-Item -Type Dir .\\$name\\themes
 
 Copy-Item .\\install_win.cmd .\\$name -force
 Copy-Item .\\install_mac.sh .\\$name -force
@@ -20,6 +21,7 @@ Copy-item .\\app\\* .\\$name\\app -force -recurse
 Copy-item .\\CSXS\\* .\\$name\\CSXS -force -recurse
 Copy-item .\\icons\\* .\\$name\\icons -force -recurse
 Copy-item .\\locale\\* .\\$name\\locale -force -recurse
+Copy-item .\\themes\\* .\\$name\\themes -force -recurse
 
 Compress-Archive .\\$name .\\$name.zip
 

--- a/pack.zxp.cmd
+++ b/pack.zxp.cmd
@@ -14,6 +14,7 @@ xcopy app %tmpDir%\app\ /E/Y/C
 xcopy CSXS %tmpDir%\CSXS\ /E/Y/C
 xcopy icons %tmpDir%\icons\ /E/Y/C
 xcopy locale %tmpDir%\locale\ /E/Y/C
+xcopy themes %tmpDir%\themes\ /E/Y/C
 
 ZXPSignCmd -selfSignedCert RU SPB 34squad "34th squad" %pass% %sert%
 ZXPSignCmd -sign %tmpDir% %name%.zxp %sert% %pass% -tsa http://timestamp.digicert.com/


### PR DESCRIPTION
## Summary
- copy the `themes` directory during install and packaging

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629e80c8d0832f95449743c66e48bd