### PR TITLE
Add option to disable Folder Priority feature

### DIFF
--- a/app_src/components/modal/export.jsx
+++ b/app_src/components/modal/export.jsx
@@ -46,6 +46,7 @@ const ExportModal = React.memo(function ExportModal() {
       data.language = context.state.language;
       data.autoClosePSD = context.state.autoClosePSD;
       data.autoScrollStyle = context.state.autoScrollStyle;
+      data.currentFolderTagPriority = context.state.currentFolderTagPriority;
       data.textItemKind = context.state.setTextItemKind;
     }
     window.cep.fs.writeFile(pathSelect.data, JSON.stringify(data));

--- a/app_src/components/modal/settings.jsx
+++ b/app_src/components/modal/settings.jsx
@@ -25,6 +25,9 @@ const SettingsModal = React.memo(function SettingsModal() {
   const [autoScrollStyle, setAutoScrollStyle] = React.useState(
     context.state.autoScrollStyle !== false
   );
+  const [currentFolderTagPriority, setCurrentFolderTagPriority] = React.useState(
+    context.state.currentFolderTagPriority !== false
+  );
   const [checkUpdates, setCheckUpdates] = React.useState(
     context.state.checkUpdates !== false
   );
@@ -84,6 +87,10 @@ const SettingsModal = React.memo(function SettingsModal() {
   };
   const changeAutoScrollStyle = (e) => {
     setAutoScrollStyle(e.target.checked);
+    setEdited(true);
+  };
+  const changeCurrentFolderTagPriority = (e) => {
+    setCurrentFolderTagPriority(e.target.checked);
     setEdited(true);
   };
 
@@ -148,6 +155,12 @@ const SettingsModal = React.memo(function SettingsModal() {
       context.dispatch({
         type: "setAutoScrollStyle",
         value: autoScrollStyle,
+      });
+    }
+    if (currentFolderTagPriority !== context.state.currentFolderTagPriority) {
+      context.dispatch({
+        type: "setCurrentFolderTagPriority",
+        value: currentFolderTagPriority,
       });
     }
     if (checkUpdates !== context.state.checkUpdates) {
@@ -438,6 +451,15 @@ const SettingsModal = React.memo(function SettingsModal() {
               <div className="field-input">
                 <label className="topcoat-checkbox">
                   <input type="checkbox" checked={autoScrollStyle} onChange={changeAutoScrollStyle} />
+                  <div className="topcoat-checkbox__checkmark"></div>
+                </label>
+              </div>
+            </div>
+            <div className="field hostBrdTopContrast">
+              <div className="field-label">{locale.settingsCurrentFolderTagPriorityLabel}</div>
+              <div className="field-input">
+                <label className="topcoat-checkbox">
+                  <input type="checkbox" checked={currentFolderTagPriority} onChange={changeCurrentFolderTagPriority} />
                   <div className="topcoat-checkbox__checkmark"></div>
                 </label>
               </div>

--- a/locale/de_DE/messages.properties
+++ b/locale/de_DE/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Rechts nach Links
 settingsMiddleEastLabel=Middle East Modus
 settingsAutoClosePsdLabel=PSD automatisch schließen
 settingsAutoScrollStyleLabel=Beim Auswählen zum Stil scrollen
+settingsCurrentFolderTagPriorityLabel=Priorität für Tags des aktuellen Ordners aktivieren
 settingsCheckUpdatesLabel=Automatisch nach Updates suchen
 settingsCheckUpdatesButton=Nach Updates suchen
 settingsImport=Alle Einstellungen und Stile importieren

--- a/locale/es_SP/messages.properties
+++ b/locale/es_SP/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Derecha a Izquierda
 settingsMiddleEastLabel=Modo Oriente Medio
 settingsAutoClosePsdLabel=Cerrar automáticamente el PSD
 settingsAutoScrollStyleLabel=Desplazar automáticamente al estilo seleccionado
+settingsCurrentFolderTagPriorityLabel=Habilitar prioridad de etiquetas de la carpeta actual
 settingsCheckUpdatesLabel=Buscar actualizaciones automáticamente
 settingsCheckUpdatesButton=Buscar actualizaciones
 settingsImport=Importar todas las configuraciones y estilos

--- a/locale/fr_FR/messages.properties
+++ b/locale/fr_FR/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Droite à Gauche
 settingsMiddleEastLabel=Mode Moyen-Orient
 settingsAutoClosePsdLabel=Fermer automatiquement le PSD
 settingsAutoScrollStyleLabel=Faire défiler jusqu’au style sélectionné
+settingsCurrentFolderTagPriorityLabel=Activer la priorité des tags du dossier courant
 settingsCheckUpdatesLabel=Rechercher automatiquement les mises à jour
 settingsCheckUpdatesButton=Rechercher les mises à jour
 settingsImport=Importer des styles ou paramètres

--- a/locale/messages.properties
+++ b/locale/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Right to Left
 settingsMiddleEastLabel=Middle Eastern text mode
 settingsAutoClosePsdLabel=Auto close PSD
 settingsAutoScrollStyleLabel=Auto scroll to selected style
+settingsCurrentFolderTagPriorityLabel=Enable current folder tag priority
 settingsCheckUpdatesLabel=Check for updates automatically
 settingsCheckUpdatesButton=Check for updates
 settingsImport=Import styles or settings

--- a/locale/pt_BR/messages.properties
+++ b/locale/pt_BR/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Direita para Esquerda
 settingsMiddleEastLabel=Modo Oriente Médio
 settingsAutoClosePsdLabel=Fechar PSD automaticamente
 settingsAutoScrollStyleLabel=Rolar até o estilo selecionado
+settingsCurrentFolderTagPriorityLabel=Ativar prioridade de tags da pasta atual
 settingsCheckUpdatesLabel=Verificar atualizações automaticamente
 settingsCheckUpdatesButton=Verificar atualizações
 settingsImport=Importar todas as configurações e estilos

--- a/locale/ru_RU/messages.properties
+++ b/locale/ru_RU/messages.properties
@@ -88,6 +88,7 @@ settingsDirectionRtl=Справа налево
 settingsMiddleEastLabel=Режим Ближнего Востока
 settingsAutoClosePsdLabel=Автоматически закрывать PSD
 settingsAutoScrollStyleLabel=Прокручивать к выбранному стилю
+settingsCurrentFolderTagPriorityLabel=Включить приоритет тегов текущей папки
 settingsCheckUpdatesLabel=Автоматически проверять обновления
 settingsCheckUpdatesButton=Проверить обновления
 settingsImport=Импортировать все параметры и стили

--- a/locale/tr_TR/messages.properties
+++ b/locale/tr_TR/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Sağdan Sola
 settingsMiddleEastLabel=Orta Doğu modu
 settingsAutoClosePsdLabel=PSD yi otomatik kapat
 settingsAutoScrollStyleLabel=Seçilen stile otomatik kaydır
+settingsCurrentFolderTagPriorityLabel=Geçerli klasör etiket önceliğini etkinleştir
 settingsCheckUpdatesLabel=Güncellemeleri otomatik olarak denetle
 settingsCheckUpdatesButton=Güncellemeleri denetle
 settingsImport=Ayarları ve stilleri içe aktarın

--- a/locale/uk_UA/messages.properties
+++ b/locale/uk_UA/messages.properties
@@ -89,6 +89,7 @@ settingsDirectionRtl=Справа наліво
 settingsMiddleEastLabel=Режим Близького Сходу
 settingsAutoClosePsdLabel=Автоматично закривати PSD
 settingsAutoScrollStyleLabel=Автопрокрутка до обраного стилю
+settingsCurrentFolderTagPriorityLabel=Увімкнути пріоритет тегів поточної теки
 settingsCheckUpdatesLabel=Автоматично перевіряти оновлення
 settingsCheckUpdatesButton=Перевірити оновлення
 settingsImport=Імпортувати всі налаштування та стилі

--- a/locale/vi_VN/messages.properties
+++ b/locale/vi_VN/messages.properties
@@ -90,6 +90,7 @@ settingsDirectionRtl=Phải sang Trái
 settingsMiddleEastLabel=Chế độ Trung Đông
 settingsAutoClosePsdLabel=Tự động đóng PSD
 settingsAutoScrollStyleLabel=Tự cuộn đến kiểu đã chọn
+settingsCurrentFolderTagPriorityLabel=Bật ưu tiên ký hiệu của thư mục hiện tại
 settingsCheckUpdatesLabel=Tự động kiểm tra cập nhật
 settingsCheckUpdatesButton=Kiểm tra cập nhật
 settingsImport=Nhập tất cả cài đặt và các kiểu


### PR DESCRIPTION
a new setting that allows users to disable the behavior where the current folder takes priority over the top folder when working with tags.